### PR TITLE
refactor: altera prefixo dos endpoints de /cefpm-api para /api

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=cefom-api
 server.port=8081
-server.servlet.context-path=/cefom-api
+server.servlet.context-path=/api
 
 
 


### PR DESCRIPTION
Foi alterado o prefixo dos endpoints da API.
Antes: ip/cefpm-api/entidades
Agora: ip/api/entidades

A mudança visa simplificar as rotas e padronizar o acesso à API.