### PR TITLE
chore: liberar CORS para qualquer origem em desenvolvimento

### DIFF
--- a/src/main/java/com/projeto/cefom/configuration/CorsConfig.java
+++ b/src/main/java/com/projeto/cefom/configuration/CorsConfig.java
@@ -7,10 +7,21 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    /*
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://127.0.0.1:5500")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+    */
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*") // libera qualquer origem
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
Ajusta a configuração de CORS para permitir qualquer origem durante o desenvolvimento do sistema.

Essa alteração é temporária e deve ser revisada antes do deploy em produção, onde as origens devem ser restritas.